### PR TITLE
Init README info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | --- | --- | --- |
 | Ben Carlin | Software Engineer | @benjamincarlin |
 | Dan Moran | Tech Lead | @danxmoran |
-| Emily Munro-Ludders | Scrum Master | |
+| Emily Munro-Ludders | Scrum Master | @emunrolu |
 | Jeff Korte | Product Owner | @JeffKorte |
 | Kathy Reinold | Data Modeler | @kreinold |
 


### PR DESCRIPTION
Inspired by [Hornet's equivalent repo](https://github.com/broadinstitute/hornet). We're churning out a bunch of new GitHub repos and I wanted to make sure they're all written down somewhere. Eventually I'd like to move all of our team overview docs here and use something [like this](https://github.com/madhead/doktor) to mirror the content into Confluence. 