### PR TITLE
install-tools bugfix

### DIFF
--- a/getting-started/pages/group-team-setup.md
+++ b/getting-started/pages/group-team-setup.md
@@ -102,6 +102,7 @@ Once you have an account, follow these steps to set up local credentials:
    /bin/cat <<-EOF > ~/.config/aws/env
    export AWS_ACCESS_KEY_ID=<your-key-id>
    export AWS_SECRET_ACCESS_KEY=<your-secret>
+   export AWS_REGION=<your-aws-region>
    EOF
 
    # Load configs into your profile.

--- a/getting-started/pages/group-team-setup.md
+++ b/getting-started/pages/group-team-setup.md
@@ -99,11 +99,11 @@ Once you have an account, follow these steps to set up local credentials:
    ```bash
    # Write config to disk.
    mkdir -p ~/.config/aws
-   /bin/cat <-EOF > ~/.config/aws/env
+   /bin/cat <<-EOF > ~/.config/aws/env
    export AWS_ACCESS_KEY_ID=<your-key-id>
    export AWS_SECRET_ACCESS_KEY=<your-secret>
    EOF
 
    # Load configs into your profile.
-   echo "source '${HOME}/.config/aws'" >> ~/.bash_profile
+   echo "source '${HOME}/.config/aws/env'" >> ~/.bash_profile
    ```

--- a/getting-started/scripts/install-tools
+++ b/getting-started/scripts/install-tools
@@ -163,8 +163,8 @@ function install_gcloud_sdk () {
 }
 
 function log_in () {
-  # Removing exisitng docker configs - unable to run the login command until this is done
-  1>&2 echo Removing exisitng docker configs...
+  # Removing existing docker configs - unable to run the login command until this is done
+  1>&2 echo Removing existing docker configs...
   rm -rf ~/.docker
   1>&2 echo Logging into DockerHub...
   docker login

--- a/getting-started/scripts/install-tools
+++ b/getting-started/scripts/install-tools
@@ -10,6 +10,8 @@ declare -ra HOMEBREW_CASKS=(
   jetbrains-toolbox
   # Lightweight editor for when a full IDE is overkill
   visual-studio-code
+  # Open, pre-built binaries of the reference implementation of the Java platform from OpenJDK
+  adoptopenjdk
 )
 
 declare -ra HOMEBREW_FORMULAE=(
@@ -147,7 +149,7 @@ function install_gcloud_sdk () {
     mkdir -p ${GCLOUD_INSTALL_LOCATION}
     curl -sL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-253.0.0-darwin-x86_64.tar.gz | \
       tar xzf - --directory ${GCLOUD_INSTALL_LOCATION} && \
-      ${GCLOUD_INSTALL_LOCATION}/install.sh
+      ${GCLOUD_INSTALL_LOCATION}/google-cloud-sdk/install.sh
   else
     1>&2 echo Updating gcloud...
     gcloud components update
@@ -161,6 +163,9 @@ function install_gcloud_sdk () {
 }
 
 function log_in () {
+  # Removing exisitng docker configs - unable to run the login command until this is done
+  1>&2 echo Removing exisitng docker configs...
+  rm -rf ~/.docker
   1>&2 echo Logging into DockerHub...
   docker login
 
@@ -183,7 +188,7 @@ function main () {
   install_homebrew
   install_homebrew_casks
   install_homebrew_fomulae
-  rewrite_settings
+  #rewrite_settings
   restart_homebrew_services
   install_gcloud_sdk
   log_in

--- a/getting-started/scripts/install-tools
+++ b/getting-started/scripts/install-tools
@@ -116,26 +116,6 @@ function install_homebrew_fomulae () {
   done
 }
 
-function rewrite_settings () {
-  local -ra sbt_patch_command=(
-    sed -i ''
-    's/#-mem.*/-mem 8192/g'
-    /usr/local/etc/sbtopts
-  )
-
-  local -ra kafka_patch_command=(
-    sed -i ''
-    's$#listeners=PLAINTEXT://:9092$listeners=PLAINTEXT://localhost:9092$g'
-    /usr/local/etc/kafka/server.properties
-  )
-
-  1>&2 echo Patching Homebrew\'s default configs...
-  1>&2 echo Running "'${sbt_patch_command[*]}'" to bump sbt\'s default memory...
-  "${sbt_patch_command[@]}"
-  1>&2 echo Running "'${kafka_patch_command[*]}'" to point Kafka at localhost...
-  "${kafka_patch_command[@]}"
-}
-
 function restart_homebrew_services () {
   1>&2 echo '('re')'Starting Homebrew-based services...
   for service in ${HOMEBREW_SERVICES[@]}; do
@@ -188,7 +168,6 @@ function main () {
   install_homebrew
   install_homebrew_casks
   install_homebrew_fomulae
-  #rewrite_settings
   restart_homebrew_services
   install_gcloud_sdk
   log_in


### PR DESCRIPTION
Line 14: Adding adoptopenjdk to list of casks to install (necessary for gradle installation - line 23)
Line 152: Modifying the path being called to install google-cloud-sdk
....compressed file gets downloaded to {GCLOUD_INSTALL_LOCATION}
....after unzip, install script is located at:"${GCLOUD_INSTALL_LOCATION}/google-cloud-sdk/install.sh" (not ${GCLOUD_INSTALL_LOCATION}/install.sh)
....Note that this script attempts to modify ~/.bash_profile, which requires root access. This can be solved by either modifying the owner of that file to be the user or running the install script separately as root.
Line 168: Removing the existing docker configs because they are interfering with the execution of the "docker logi"n command