### PR TITLE
Remove installation of sleep prevention app from setup scripts

### DIFF
--- a/getting-started/pages/dev-setup.md
+++ b/getting-started/pages/dev-setup.md
@@ -19,7 +19,6 @@ If you aren't running OS X, I'm sorry.
 The installation script will download a few OS X applications, but you'll need to manually
 start them. Use spotlight to find and launch:
 * `Docker.app`
-* `KeepingYouAwake.app`
 * `JetBrains Toolbox.app`
 * `Visual Studio Code.app`
 

--- a/getting-started/scripts/install-tools
+++ b/getting-started/scripts/install-tools
@@ -4,8 +4,6 @@ set -euo pipefail
 declare -ra HOMEBREW_CASKS=(
   # Community Edition
   docker
-  # Utility that can prevent your Mac from entering sleep mode
-  keepingyouawake
   # Installation manager for Jetbrains IDEs
   jetbrains-toolbox
   # Lightweight editor for when a full IDE is overkill


### PR DESCRIPTION
At infosec's request, we've removed this application to avoid it causing problems with our audits, since we're required to have our laptops configured to lock after an org-designated period of inactivity. Anyone with it installed should probably also uninstall it.